### PR TITLE
Enable FTScroller on Firefox

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -732,9 +732,7 @@ var FTScroller, CubicBezier;
 
 				// If the gesture distance has exceeded the scroll lock distance, or snapping is active
 				// and the scroll has been interrupted, enture exclusive scrolling.
-				if ((scrollInterrupt && _instanceOptions.snapping) ||
-					(_scrollableAxes.x && Math.abs(gesture.x) >= _instanceOptions.scrollBoundary) ||
-					(_scrollableAxes.y && Math.abs(gesture.y) >= _instanceOptions.scrollBoundary)) {
+				if ((scrollInterrupt && _instanceOptions.snapping) || (_scrollableAxes.x && Math.abs(gesture.x) >= _instanceOptions.scrollBoundary) || (_scrollableAxes.y && Math.abs(gesture.y) >= _instanceOptions.scrollBoundary)) {
 
 					_isScrolling = true;
 					_ftscrollerMoving = _self;


### PR DESCRIPTION
Enable FTScroller on devices where 'ontouchstart' is not a direct
property of the document object. Tested on -Android 4.0: Firefox for
Android, Chrome for Android, Opera (functional but bad performance),
Internet. Android 2.2: Browser. iOS3 iPhone: Safari. iOS6  iPad mini:
Safari. Fixes #20.
