### PR TITLE
Added `scrollinteractionend` event

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -334,7 +334,8 @@ var FTScroller, CubicBezier;
 			'segmentwillchange': [],
 			'segmentdidchange': [],
 			'reachedstart': [],
-			'reachedend': []
+			'reachedend': [],
+			'scrollinteractionend': []
 		};
 
 		// MutationObserver instance, when supported and if DOM change sniffing is enabled
@@ -794,6 +795,9 @@ var FTScroller, CubicBezier;
 			_inputIdentifier = false;
 			_releaseInputCapture();
 			_cancelAnimation();
+
+			_fireEvent('scrollinteractionend', {});
+
 			if (!_isScrolling) {
 				if (!_snapScroll(true) && _scrollbarsVisible) {
 					_finalizeScroll(true);


### PR DESCRIPTION
Is fired on pointer/touch end type event. Required for 'pull to refesh' style functionality.
