### PR TITLE
Scrollend event is now fired even when the scrolling has been cancelled ...

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -849,8 +849,10 @@ var FTScroller, CubicBezier;
 			if (!scrollCancelled) {
 				_fireEvent('scroll', { scrollLeft: -_baseScrollPosition.x, scrollTop: -_baseScrollPosition.y });
 				_updateSegments(true);
-				_fireEvent('scrollend', { scrollLeft: -_baseScrollPosition.x, scrollTop: -_baseScrollPosition.y });
 			}
+
+			// Even if scrolling is cancelled, we want to know when the scrolling ends.
+      		_fireEvent('scrollend', { scrollLeft: -_baseScrollPosition.x, scrollTop: -_baseScrollPosition.y });
 
 			// Restore transitions
 			for (axis in _scrollableAxes) {


### PR DESCRIPTION
Before, the scrollend event would not be triggered when the user would cancel the scroll. This quick hack allows the event to be triggered after each scroll, canceled or not.

An alternative solution would be to create a scrollcancel event but on my side I haven't seen any downside to the current hack.
