### PR TITLE
fix common.js exports 

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -2570,7 +2570,7 @@ var FTScroller, CubicBezier;
 }());
 
 // If a CommonJS environment is present, add our exports; make the check in a jslint-compatible method.
-if (typeof module === 'object' && module.exports) {
+if (typeof module !== 'undefined' && module.exports) {
 	module.exports = function(domNode, options) {
 		'use strict';
 		return new FTScroller(domNode, options);


### PR DESCRIPTION
this fix common.js export when using component.js
typeof module is a function so the current code fail to export the scroller 
and expose in the global namespace instead
