### PR TITLE
Option to disable the fling of a scroller

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -222,6 +222,9 @@ var FTScroller, CubicBezier;
 			// Allow scroll bouncing and elasticity near the ends and grid
 			bouncing: true,
 
+			// Enable fling
+			fling: true,
+
 			// Automatically detects changes to the contained markup and
 			// updates its dimensions whenever the content changes. This is
 			// set to false if a contentWidth or contentHeight are supplied.
@@ -936,7 +939,7 @@ var FTScroller, CubicBezier;
 					movementSpeed = (lastPosition[axis] - comparisonPosition[axis]) / (lastPosition.t - comparisonPosition.t);
 
 					// If there is little speed, no further action required except for a bounceback, below.
-					if (Math.abs(movementSpeed) < _kMinimumSpeed) {
+					if (Math.abs(movementSpeed) < _kMinimumSpeed || !_instanceOptions.fling) {
 						flingDuration = 0;
 						flingDistance = 0;
 


### PR DESCRIPTION
Sometimes, one doesn't the scroller to animate the element after the touch interaction has stopeed.
I added an boolean option to completely disable the fling of a scroller.
Example:

```
new FTScroller(el, {
    fling: false
});
```

What do you think?
