### PR TITLE
enableRequestAnimationFrameSupport option isn't used in the code

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -386,6 +386,9 @@ var FTScroller, CubicBezier;
 			_baseScrollableAxes.y = true;
 		}
 
+		_reqAnimationFrame = _instanceOptions.enableRequestAnimationFrameSupport && _reqAnimationFrame;
+		_cancelAnimationFrame = _instanceOptions.enableRequestAnimationFrameSupport && _cancelAnimationFrame;
+
 
 		/*                    Scoped Functions                   */
 


### PR DESCRIPTION
There's an option to enable/disable the requestAnimationFrame support but it doesn't do anything since it's not used in the code.
This pull request fixes it.
