### PR TITLE
Expose flingBezier, bounceBezier, flingTruncatedBezier and decelerateBezier

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -256,7 +256,13 @@ var FTScroller, CubicBezier;
 
 			// Set the maximum time (ms) that a fling can take to complete; if
 			// this is not set, flings will complete instantly
-			maxFlingDuration: 1000
+			maxFlingDuration: 1000,
+
+			// Gesture details
+			flingBezier: new CubicBezier(0.1, 0.4, 0.3, 1),
+			bounceBezier: new CubicBezier(0.7, 0, 0.9, 0.6),
+			flingTruncatedBezier: new CubicBezier(0.1, 0.4, 0.3, 1).divideAtT(0.97)[0],
+			decelerateBezier: new CubicBezier(0, 0.5, 0.5, 1)
 		};
 
 
@@ -311,10 +317,10 @@ var FTScroller, CubicBezier;
 		var _gestureStart = { x: 0, y: 0, t: 0 };
 		var _cumulativeScroll = { x: 0, y: 0 };
 		var _eventHistory = [];
-		var _kFlingBezier = new CubicBezier(0.1, 0.4, 0.3, 1);
-		var _kBounceBezier = new CubicBezier(0.7, 0, 0.9, 0.6);
-		var _kFlingTruncatedBezier = _kFlingBezier.divideAtT(0.97)[0];
-		var _kDecelerateBezier = new CubicBezier(0, 0.5, 0.5, 1);
+		var _kFlingBezier;
+		var _kBounceBezier;
+		var _kFlingTruncatedBezier;
+		var _kDecelerateBezier;
 
 		// Allow certain events to be debounced
 		var _domChangeDebouncer = false;
@@ -385,6 +391,11 @@ var FTScroller, CubicBezier;
 		if (_instanceOptions.scrollingY) {
 			_baseScrollableAxes.y = true;
 		}
+
+		_kFlingBezier = _instanceOptions.flingBezier;
+		_kBounceBezier = _instanceOptions.bounceBezier;
+		_kFlingTruncatedBezier = _instanceOptions.flingTruncatedBezier;
+		_kDecelerateBezier = _instanceOptions.decelerateBezier;
 
 
 		/*                    Scoped Functions                   */


### PR DESCRIPTION
This commit exposes the 4 bezier properties (flingBezier, bounceBezier, flingTruncatedBezier and decelerateBezier) as options.
It allows one to tweak the behavior of the scroller.

These were declared as local variables (var _kFlingBezier, ...) so I kept them instead of rewriting everything (_kFlingBezier => _instanceOptions.flingBezier).
Tell me if you'd prefer that I replace the local variables.
