### PR TITLE
Improvements to logic when focussing a child node

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -1671,10 +1671,11 @@ var FTScroller, CubicBezier;
 		 * Update the scroll position so that the child element is in view.
 		 */
 		_childFocused = function _childFocused(event) {
-			var offset, axis;
+			var offset, axis, visibleChildPortion;
 			var focusedNodeRect = _getBoundingRect(event.target);
 			var containerRect = _getBoundingRect(_containerNode);
 			var edgeMap = { x: 'left', y: 'top' };
+			var opEdgeMap = { x: 'right', y: 'bottom' };
 			var dimensionMap = { x: 'width', y: 'height' };
 
 			// If an input is currently being tracked, ignore the focus event
@@ -1684,6 +1685,21 @@ var FTScroller, CubicBezier;
 
 			for (axis in _scrollableAxes) {
 				if (_scrollableAxes.hasOwnProperty(axis)) {
+
+					// If the focussed node is entirely in view, there is no need to center it
+					if (focusedNodeRect[edgeMap[axis]] >= containerRect[edgeMap[axis]] && focusedNodeRect[opEdgeMap[axis]] <= containerRect[opEdgeMap[axis]]) {
+						continue;
+
+					// If the focussed node is larger than the container...
+					} else if (focusedNodeRect[dimensionMap[axis]] > containerRect[dimensionMap[axis]]) {
+
+						visibleChildPortion = focusedNodeRect[dimensionMap[axis]] - Math.max(0, containerRect[edgeMap[axis]] - focusedNodeRect[edgeMap[axis]]) - Math.max(0, focusedNodeRect[opEdgeMap[axis]] - containerRect[opEdgeMap[axis]]);
+
+						// If more than half a container's portion of the focussed node is visible, there's no need to center it
+						if (visibleChildPortion >= (containerRect[dimensionMap[axis]] / 2)) {
+							continue;
+						}
+					}
 
 					// Set the target offset to be in the middle of the container, or as close as bounds permit
 					offset = -Math.round((focusedNodeRect[dimensionMap[axis]] / 2) - _lastScrollPosition[axis] + focusedNodeRect[edgeMap[axis]] - containerRect[edgeMap[axis]]  - (containerRect[dimensionMap[axis]] / 2));


### PR DESCRIPTION
Only scroll to center a focussed child node if:
- the child is smaller than the container, and is not already entirely
  in view, or:
- the child is larger than the container, and less than half a
  container's width/height of the child is visible
