### PR TITLE
Fixed "RangeError in scroller when used with mousewheel" Bug 13403 on Redmine

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -319,6 +319,9 @@ var FTScroller, CubicBezier;
 		// Allow certain events to be debounced
 		var _domChangeDebouncer = false;
 		var _scrollWheelEndDebouncer = false;
+		var _updateDebouncer = true;
+		var _updateDebounceTimeSignature=0;
+		var _updateDebounceInterval=parseInt(1000/60,10); //So it doesn't update more than 60 times persecond.
 
 		// Performance switches on browsers supporting requestAnimationFrame
 		var _animationFrameRequest = false;
@@ -647,6 +650,12 @@ var FTScroller, CubicBezier;
 		 * Continue a scroll as a result of an updated position
 		 */
 		_updateScroll = function _updateScroll(inputX, inputY, inputTime, rawEvent, scrollInterrupt) {
+			if(_updateDebouncer){
+				var timeSignature=(new Date()).getTime();
+				if((timeSignature-_updateDebounceTimeSignature)<=_updateDebounceInterval)return;
+				_updateDebounceTimeSignature=timeSignature;
+			}
+
 			var axis, otherScrollerActive;
 			var initialScroll = false;
 			var gesture = {


### PR DESCRIPTION
Added a check so that if the document scrolled a distance in 0 time. For example in a single mouse wheel scroll. It behave as this occured over the course of a single frame at 60fps. example in a single mouse wheel scroll. It behave as this occured over the course of a single frame at 60fps.
