### PR TITLE
Update width and height of scrollbars to be 7px which are actual dimensions of the iOS scrollbar

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -136,7 +136,7 @@ var FTScroller, CubicBezier;
 			'.ftscroller_hwaccelerated { ' + hardwareAccelerationRule  + ' }',
 			'.ftscroller_x, .ftscroller_y { position: relative; min-width: 100%; min-height: 100%; overflow: hidden }',
 			'.ftscroller_x { display: inline-block }',
-			'.ftscroller_scrollbar { pointer-events: none; position: absolute; width: 5px; height: 5px; border: 1px solid rgba(255, 255, 255, 0.15); -webkit-border-radius: 3px; border-radius: 6px; opacity: 0; ' + _vendorCSSPrefix + 'transition: opacity 350ms; z-index: 10 }',
+			'.ftscroller_scrollbar { pointer-events: none; position: absolute; width: 7px; height: 7px; border: 1px solid rgba(255, 255, 255, 0.15); -webkit-border-radius: 3px; border-radius: 6px; opacity: 0; ' + _vendorCSSPrefix + 'transition: opacity 350ms; z-index: 10 }',
 			'.ftscroller_scrollbarx { bottom: 2px; left: 2px }',
 			'.ftscroller_scrollbary { right: 2px; top: 2px }',
 			'.ftscroller_scrollbarinner { height: 100%; background: rgba(0,0,0,0.5); -webkit-border-radius: 2px; border-radius: 4px / 6px }',


### PR DESCRIPTION
Update width and height of scrollbars to be 7px which are actual dimensions of the iOS scrollbar. This change should be applicable for most implementations.
