### PR TITLE
Performance tweaking for large container content structures

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -129,20 +129,21 @@ var FTScroller, CubicBezier;
 			hardwareAccelerationRule = _vendorCSSPrefix + 'transform: translateZ(0);';
 		}
 
-		// Add our rules
-		_styleText = [
-			'.ftscroller_scrolling { ' + _vendorCSSPrefix + 'user-select: none; cursor: all-scroll !important }',
-			'.ftscroller_container { overflow: hidden; position: relative; max-height: 100%; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); -ms-touch-action: none }',
-			'.ftscroller_hwaccelerated { ' + hardwareAccelerationRule  + ' }',
-			'.ftscroller_x, .ftscroller_y { position: relative; min-width: 100%; min-height: 100%; overflow: hidden }',
-			'.ftscroller_x { display: inline-block }',
-			'.ftscroller_scrollbar { pointer-events: none; position: absolute; width: 5px; height: 5px; border: 1px solid rgba(255, 255, 255, 0.15); -webkit-border-radius: 3px; border-radius: 6px; opacity: 0; ' + _vendorCSSPrefix + 'transition: opacity 350ms; z-index: 10 }',
-			'.ftscroller_scrollbarx { bottom: 2px; left: 2px }',
-			'.ftscroller_scrollbary { right: 2px; top: 2px }',
-			'.ftscroller_scrollbarinner { height: 100%; background: rgba(0,0,0,0.5); -webkit-border-radius: 2px; border-radius: 4px / 6px }',
-			'.ftscroller_scrolling .ftscroller_scrollbar { opacity: 1; ' + _vendorCSSPrefix + 'transition: none; -o-transition: all 0 none }',
-			'.ftscroller_scrolling .ftscroller_container .ftscroller_scrollbar { opacity: 0 }'
-		];
+    // Add our rules
+    _styleText = [
+      '.ftscroller_scrolling { ' + _vendorCSSPrefix + 'user-select: none; cursor: all-scroll !important; }',
+      '.ftscroller_container { overflow: hidden; position: relative; max-height: 100%; -webkit-tap-highlight-color: rgba(0, 0, 0, 0); -ms-touch-action: none }',
+      '.ftscroller_hwaccelerated { ' + hardwareAccelerationRule  + ' }',
+      '.ftscroller_x, .ftscroller_y { position: relative; min-width: 100%; min-height: 100%; overflow: hidden }',
+      '.ftscroller_x { display: inline-block }',
+      '.ftscroller_scrollbar { pointer-events: none; position: absolute; width: 5px; height: 5px; border: 1px solid rgba(255, 255, 255, 0.15); -webkit-border-radius: 3px; border-radius: 6px; opacity: 0; ' + _vendorCSSPrefix + 'transition: opacity 350ms; z-index: 10 }',
+      '.ftscroller_scrollbarx { bottom: 2px; left: 2px }',
+      '.ftscroller_scrollbary { right: 2px; top: 2px }',
+      '.ftscroller_scrollbarinner { height: 100%; background: rgba(0,0,0,0.5); -webkit-border-radius: 2px; border-radius: 4px / 6px }',
+      '.ftscroller_scrolling .ftscroller_scrollbar { opacity: 1; ' + _vendorCSSPrefix + 'transition: none; -o-transition: all 0 none }',
+      '.ftscroller_scrolling .ftscroller_container .ftscroller_scrollbar { opacity: 0 }',
+      '.ftscroller_scrollbar.ftscroller_scrolling_tweak { opacity: 1; ' + _vendorCSSPrefix + 'transition: none; -o-transition: all 0 none }'
+    ];
 
 		if (newStyleNode.styleSheet) {
 			newStyleNode.styleSheet.cssText = _styleText.join('\n');
@@ -256,7 +257,16 @@ var FTScroller, CubicBezier;
 
 			// Set the maximum time (ms) that a fling can take to complete; if
 			// this is not set, flings will complete instantly
-			maxFlingDuration: 1000
+			maxFlingDuration: 1000,
+
+
+      // Enables a different way of styling the scrollbar / container. It prevents
+      // the browser from recalculating the styles on all content nodes in the container
+      // when starting the scroll. This is useful when having a very large content tree
+      // and/or complex CSS rules. It minimized interaction latency. Drawbacks:
+      // possibly problems with nested scrollers, not possible to style the container
+      // when scrolling.
+      tweakContainerStyling: false
 		};
 
 
@@ -768,9 +778,20 @@ var FTScroller, CubicBezier;
 
 			// To aid render/draw coalescing, perform other one-off actions here
 			if (initialScroll) {
-				if (_containerNode.className.indexOf('ftscroller_scrolling') === -1) {
-					_containerNode.className += ' ftscroller_scrolling';
-				}
+
+        if (_instanceOptions.tweakContainerStyling) {
+          for (axis in _scrollableAxes) {
+            if (_scrollableAxes.hasOwnProperty(axis)
+              && _scrollbarNodes[axis].className.indexOf('ftscroller_scrolling_tweak') === -1) {
+              _scrollbarNodes[axis].className += ' ftscroller_scrolling_tweak';
+            }
+          }
+        } else {
+          if (_containerNode.className.indexOf('ftscroller_scrolling') === -1) {
+            _containerNode.className += ' ftscroller_scrolling';
+          }
+        }
+
 			}
 
 			// If full, locked scrolling has enabled, fire any scroll and segment change events
@@ -839,10 +860,19 @@ var FTScroller, CubicBezier;
 			_scrollbarsVisible = false;
 			_isDisplayingScroll = false;
 
-			// Remove scrolling class
-			_containerNode.className = _containerNode.className.replace(/ ?ftscroller_scrolling/g, '');
 
-			// Store final position if scrolling occurred
+      if (_instanceOptions.tweakContainerStyling) {
+        for (axis in _scrollableAxes) {
+          if (_scrollableAxes.hasOwnProperty(axis)) {
+            _scrollbarNodes[axis].className = _scrollbarNodes[axis].className.replace(/ ?ftscroller_scrolling_tweak/g, '');
+          }
+        }
+      } else {
+        // Remove scrolling class
+        _containerNode.className = _containerNode.className.replace(/ ?ftscroller_scrolling/g, '');
+      }
+
+      // Store final position if scrolling occurred
 			_baseScrollPosition.x = _lastScrollPosition.x;
 			_baseScrollPosition.y = _lastScrollPosition.y;
 


### PR DESCRIPTION
I think I have to explain a little bit why I wrote this patch: using an iPhone4 device, there always was a noticeable performance lag just before scrolling. It's like a delay after touching and before the scrolling begins. This did not occur in the examples. 

Analyzing this lag, I noticed two things: first, I had several CSS \* selectors, second, the content structure being scrolled is quite large. Removing the \* selectors seemed to solve the problem, but it came again when the structure was yet larger (using infinite scrolling with ajax).

Then I did further analysis within the Chrome Timeline which showed that styles are being recalculated for all container elements just before scrolling begins. When leaving away the CSS for the 'ftscroller_scrolling' class everything runs very smoothly - however at the cost of losing some styles (user-select:none and cursor:scroll-all).

So I wrote this patch which adds an option to not trigger these styles on the container itself, but just on the scrollbar. I am not sure this is the best solution - I think it would be better to make the CSS better customizable, but this would need changes to the embedding of the CSS. I'm open to help here after discussing the general direction.
