### PR TITLE
enabled orthogonal scrolling

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -723,7 +723,7 @@ var FTScroller, CubicBezier;
 
 				// Determine whether to prevent the default scroll event - if the scroll could still
 				// be triggered, prevent the default to avoid problems (particularly on PlayBook)
-				if (_instanceOptions.bouncing || scrollInterrupt || (_scrollableAxes.x && gesture.x && distancesBeyondBounds.x < 0) || (_scrollableAxes.y && gesture.y && distancesBeyondBounds.y < 0)) {
+				if (_instanceOptions.bouncing || scrollInterrupt || (_scrollableAxes.x && gesture.x && Math.abs(gesture.x) > _instanceOptions.scrollResponseBoundary) || (_scrollableAxes.y && gesture.y && Math.abs(gesture.y) > _instanceOptions.scrollResponseBoundary)) {
 					rawEvent.preventDefault();
 				}
 


### PR DESCRIPTION
This enables vertical page scrolling on a page with a horizontal ftscroller. The `scrollBoundary` and `scrollResponseBoundary` options have to be set accordingly. For me `10` feels like a good tradeoff.
