### PR TITLE
Allow nested elements to pick up events before they get to ftscroller

### DIFF
--- a/examples/horizontalpaged-with-nested-slider.html
+++ b/examples/horizontalpaged-with-nested-slider.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html>
+<head>
+  <title>FT scroller demo: horizontal paged with nested slider</title>
+  <style>
+
+    /* Styles not relevant to scrolling (just to make the demo look neat and tidy) */
+    body { font-family: sans-serif; -webkit-text-size-adjust: 100% }
+    #scrollable section:nth-child(2n) { background-color: #eee;}
+
+    /* Set the size of the scroller.  Visible border to make the demo easier to understand */
+    #scrollable { white-space: nowrap; width: 600px; height: 400px; border: 1px solid gray; overflow: hidden }
+
+    /* Style each 'page' to be the same size and join together into a long horizontal strip.  Use display: table on the section wrapper to get rid of whitespace between the inline-blocks. */
+    #sectionwrapper { width: 3600px; display: table }
+    #sectionwrapper section { width: 600px; height: 400px; display: inline-block; vertical-align: top;}
+    #sectionwrapper section div { padding: 50px; overflow: hidden; white-space: normal;}
+
+  </style>
+</head>
+<body>
+  <div id='scrollable'>
+    <div id='sectionwrapper'>
+      <section>
+        <div>Form 1
+        <form>
+          <div class="age-field">Age <span class="age">0</span></div>
+          <input class="age-slider" type="range" min="0" max="100"/>
+        </form>
+        <p>Swipe left to scroll the next page into view.  If you swipe quickly...</p></div></section>
+      <section><div>Page 2<p>...lots...</p></div></section>
+      <section><div>Page 3<p>...and lots...</p></div></section>
+      <section><div>Page 4<p>...of pages...</p></div></section>
+      <section><div>Page 5<p>...in one single...</p></div></section>
+      <section><div>Page 6<p>...scroll movement.  FTScroller will snap to the nearest page when the scroll animation comes to rest.</p></div></section>
+    </div>
+  </div>
+
+  <!--Include FT Scroller source (can be included at any point as long as it's loaded before being used)-->
+  <script src='../lib/ftscroller.js'></script>
+
+  <!--Set up the scroller-->
+  <script>
+    var scroller = new FTScroller(document.getElementById('scrollable'), {
+      scrollingY: false,
+      snapping: true,
+      scrollbars: false
+    });
+
+    var ageSlider = document.querySelector('.age-slider');
+    var ageValue = document.querySelector('.age');
+
+    var updateAge = function() {
+      ageValue.innerText = ageSlider.value;
+    }
+
+    ageSlider.addEventListener('mousedown', function(e) {
+      e.stopPropagation();
+    });
+
+    ageSlider.addEventListener('change', function(e) {
+      updateAge();
+    });
+
+    updateAge();
+  </script>
+</body>
+</html>

--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -1972,8 +1972,8 @@ var FTScroller, CubicBezier;
 				}
 			}
 			if (!_instanceOptions.disabledInputMethods.scroll) {
-				_containerNode._ftscrollerToggle('DOMMouseScroll', _onMouseScroll);
-				_containerNode._ftscrollerToggle('mousewheel', _onMouseScroll);
+				_containerNode._ftscrollerToggle('DOMMouseScroll', _onMouseScroll, true);
+				_containerNode._ftscrollerToggle('mousewheel', _onMouseScroll, true);
 			}
 
 			// Add a click listener.  On IE, add the listener to the document, to allow


### PR DESCRIPTION
This is basically a duplicate of https://github.com/ftlabs/ftscroller/pull/13 but up to date.

Using capturing instead of bubbling for events is a complete pain if you have anything inside a scroller than needs to respond to drag events. For example, I have audio players embedded in a scrollable page.

There is mention of issues with IE10 but I can't see any direct reference to the actual problem. The original use of event capturing was in the project from the beginning.
