### PR TITLE
Syntax will no longer cause errors in IE8.

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -63,12 +63,18 @@ var FTScroller, CubicBezier;
 
 	// Determine whether pointer events or touch events can be used
 	var _trackPointerEvents = window.navigator.msPointerEnabled;
-	var _trackTouchEvents = !_trackPointerEvents && (window.propertyIsEnumerable('ontouchstart') || window.document.hasOwnProperty('ontouchstart'));
+	var _trackTouchEvents = false;
+	if ('propertyIsEnumerable' in window || 'hasOwnProperty' in window.document) {
+		_trackTouchEvents = !_trackPointerEvents && (window.propertyIsEnumerable('ontouchstart') || window.document.hasOwnProperty('ontouchstart'));
+	}
 
 	// Determine whether to use modern hardware acceleration rules or dynamic/toggleable rules.
 	// Certain older browsers - particularly Android browsers - have problems with hardware
 	// acceleration, so being able to toggle the behaviour dynamically via a CSS cascade is desirable.
-	var _useToggleableHardwareAcceleration = !window.hasOwnProperty('ArrayBuffer');
+	var _useToggleableHardwareAcceleration = false;
+	if ('hasOwnProperty' in window) {
+		_useToggleableHardwareAcceleration = !window.hasOwnProperty('ArrayBuffer');
+	}
 
 	// Feature detection
 	var _canClearSelection = (window.Selection && window.Selection.prototype.removeAllRanges);
@@ -2347,30 +2353,49 @@ var FTScroller, CubicBezier;
 			scrollBy: scrollBy,
 			updateDimensions: updateDimensions,
 			addEventListener: addEventListener,
-			removeEventListener: removeEventListener,
-			get scrollHeight () { return _metrics.content.y; },
-			set scrollHeight (value) { throw new SyntaxError('scrollHeight is currently read-only - ignoring ' + value); },
-			get scrollLeft () { return -_lastScrollPosition.x; },
-			set scrollLeft (value) { scrollTo(value, false, false); return -_lastScrollPosition.x; },
-			get scrollTop () { return -_lastScrollPosition.y; },
-			set scrollTop (value) { scrollTo(false, value, false); return -_lastScrollPosition.y; },
-			get scrollWidth () { return _metrics.content.x; },
-			set scrollWidth (value) { throw new SyntaxError('scrollWidth is currently read-only - ignoring ' + value); },
-			get segmentCount () {
-				if (!_instanceOptions.snapping) {
-					return { x: NaN, y: NaN };
-				}
-				return {
-					x: Math.ceil(_metrics.content.x / _snapGridSize.x),
-					y: Math.ceil(_metrics.content.y / _snapGridSize.y)
-				};
-			},
-			set segmentCount (value) { throw new SyntaxError('segmentCount is currently read-only - ignoring ' + value); },
-			get currentSegment () { return { x: _activeSegment.x, y: _activeSegment.y }; },
-			set currentSegment (value) { throw new SyntaxError('currentSegment is currently read-only - ignoring ' + value); },
-			get contentContainerNode () { return _contentParentNode; },
-			set contentContainerNode (value) { throw new SyntaxError('contentContainerNode is currently read-only - ignoring ' + value); }
+			removeEventListener: removeEventListener
 		};
+
+		if (Object.defineProperties) {
+			Object.defineProperties(_publicSelf, {
+				'scrollHeight': {
+					get: function() { return _metrics.content.y; },
+					set: function(value) { throw new SyntaxError('scrollHeight is currently read-only - ignoring ' + value); }
+				},
+				'scrollLeft': {
+					get: function() { return -_lastScrollPosition.x; },
+					set: function(value) { scrollTo(value, false, false); return -_lastScrollPosition.x; }
+				},
+				'scrollTop': {
+					get: function() { return -_lastScrollPosition.y; },
+					set: function(value) { scrollTo(false, value, false); return -_lastScrollPosition.y; }
+				},
+				'scrollWidth': {
+					get: function() { return _metrics.content.x; },
+					set: function(value) { throw new SyntaxError('scrollWidth is currently read-only - ignoring ' + value); }
+				},
+				'segmentCount': {
+					get: function() {
+						if (!_instanceOptions.snapping) {
+							return { x: NaN, y: NaN };
+						}
+						return {
+							x: Math.ceil(_metrics.content.x / _snapGridSize.x),
+							y: Math.ceil(_metrics.content.y / _snapGridSize.y)
+						};
+					},
+					set: function(value) { throw new SyntaxError('segmentCount is currently read-only - ignoring ' + value); }
+				},
+				'currentSegment': {
+					get: function() { return { x: _activeSegment.x, y: _activeSegment.y }; },
+					set: function(value) { throw new SyntaxError('currentSegment is currently read-only - ignoring ' + value); }
+				},
+				'contentContainerNode': {
+					get: function() { return _contentParentNode; },
+					set: function(value) { throw new SyntaxError('contentContainerNode is currently read-only - ignoring ' + value); }
+				}
+			});
+		}
 
 		// Return the public interface.
 		return _publicSelf;


### PR DESCRIPTION
The `_publicSelf` get/set operator syntax was causing errors in IE8 (even if the code wasn't run).

I've updated this to use `Object.defineProperties` if that method exists. Also there's a couple of variable declarations that I've made defensive.
