### PR TITLE
Enable event bubbling instead of capture for better nested scrollers

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -2023,30 +2023,30 @@ var FTScroller, CubicBezier;
 
 			if (_trackPointerEvents && !_instanceOptions.disabledInputMethods.pointer) {
 				if (_pointerEventsPrefixed) {
-					_containerNode.addEventListener('MSPointerDown', _onPointerDown, true);
-					_containerNode.addEventListener('MSPointerMove', _onPointerMove, true);
-					_containerNode.addEventListener('MSPointerUp', _onPointerUp, true);
-					_containerNode.addEventListener('MSPointerCancel', _onPointerCancel, true);
+					_containerNode.addEventListener('MSPointerDown', _onPointerDown);
+					_containerNode.addEventListener('MSPointerMove', _onPointerMove);
+					_containerNode.addEventListener('MSPointerUp', _onPointerUp);
+					_containerNode.addEventListener('MSPointerCancel', _onPointerCancel);
 				} else {
-					_containerNode.addEventListener('pointerdown', _onPointerDown, true);
-					_containerNode.addEventListener('pointermove', _onPointerMove, true);
-					_containerNode.addEventListener('pointerup', _onPointerUp, true);
-					_containerNode.addEventListener('pointercancel', _onPointerCancel, true);
+					_containerNode.addEventListener('pointerdown', _onPointerDown);
+					_containerNode.addEventListener('pointermove', _onPointerMove);
+					_containerNode.addEventListener('pointerup', _onPointerUp);
+					_containerNode.addEventListener('pointercancel', _onPointerCancel);
 				}
 			} else {
 				if (_trackTouchEvents && !_instanceOptions.disabledInputMethods.touch) {
-					_containerNode.addEventListener('touchstart', _onTouchStart, true);
-					_containerNode.addEventListener('touchmove', _onTouchMove, true);
-					_containerNode.addEventListener('touchend', _onTouchEnd, true);
-					_containerNode.addEventListener('touchcancel', _onTouchEnd, true);
+					_containerNode.addEventListener('touchstart', _onTouchStart);
+					_containerNode.addEventListener('touchmove', _onTouchMove);
+					_containerNode.addEventListener('touchend', _onTouchEnd);
+					_containerNode.addEventListener('touchcancel', _onTouchEnd);
 				}
 				if (!_instanceOptions.disabledInputMethods.mouse) {
-					_containerNode.addEventListener('mousedown', _onMouseDown, true);
+					_containerNode.addEventListener('mousedown', _onMouseDown);
 				}
 			}
 			if (!_instanceOptions.disabledInputMethods.scroll) {
-				_containerNode.addEventListener('DOMMouseScroll', _onMouseScroll, false);
-				_containerNode.addEventListener('mousewheel', _onMouseScroll, false);
+				_containerNode.addEventListener('DOMMouseScroll', _onMouseScroll);
+				_containerNode.addEventListener('mousewheel', _onMouseScroll);
 			}
 
 			// If any of the input methods which would eventually trigger a click are
@@ -2067,7 +2067,7 @@ var FTScroller, CubicBezier;
 
 			// Watch for changes inside the contained element to update bounds - de-bounced slightly.
 			if (!_instanceOptions.disabledInputMethods.focus) {
-				_contentParentNode.addEventListener('focus', _childFocused, true);
+				_contentParentNode.addEventListener('focus', _childFocused);
 			}
 			if (_instanceOptions.updateOnChanges) {
 
@@ -2099,10 +2099,10 @@ var FTScroller, CubicBezier;
 						_domChanged();
 					}, true);
 				}
-				_contentParentNode.addEventListener('load', _domChanged, true);
+				_contentParentNode.addEventListener('load', _domChanged);
 			}
 			if (_instanceOptions.updateOnWindowResize) {
-				window.addEventListener('resize', _domChanged, true);
+				window.addEventListener('resize', _domChanged);
 			}
 		};
 
@@ -2115,38 +2115,38 @@ var FTScroller, CubicBezier;
 		_removeEventHandlers = function _removeEventHandlers() {
 
 			if (_containerNode) {
-				_containerNode.removeEventListener('MSPointerDown', _onPointerDown, true);
-				_containerNode.removeEventListener('MSPointerMove', _onPointerMove, true);
-				_containerNode.removeEventListener('MSPointerUp', _onPointerUp, true);
-				_containerNode.removeEventListener('MSPointerCancel', _onPointerCancel, true);
-				_containerNode.removeEventListener('pointerdown', _onPointerDown, true);
-				_containerNode.removeEventListener('pointermove', _onPointerMove, true);
-				_containerNode.removeEventListener('pointerup', _onPointerUp, true);
-				_containerNode.removeEventListener('pointercancel', _onPointerCancel, true);
-				_containerNode.removeEventListener('touchstart', _onTouchStart, true);
-				_containerNode.removeEventListener('touchmove', _onTouchMove, true);
-				_containerNode.removeEventListener('touchend', _onTouchEnd, true);
-				_containerNode.removeEventListener('touchcancel', _onTouchEnd, true);
-				_containerNode.removeEventListener('mousedown', _onMouseDown, true);
-				_containerNode.removeEventListener('DOMMouseScroll', _onMouseScroll, false);
-				_containerNode.removeEventListener('mousewheel', _onMouseScroll, false);
+				_containerNode.removeEventListener('MSPointerDown', _onPointerDown);
+				_containerNode.removeEventListener('MSPointerMove', _onPointerMove);
+				_containerNode.removeEventListener('MSPointerUp', _onPointerUp);
+				_containerNode.removeEventListener('MSPointerCancel', _onPointerCancel);
+				_containerNode.removeEventListener('pointerdown', _onPointerDown);
+				_containerNode.removeEventListener('pointermove', _onPointerMove);
+				_containerNode.removeEventListener('pointerup', _onPointerUp);
+				_containerNode.removeEventListener('pointercancel', _onPointerCancel);
+				_containerNode.removeEventListener('touchstart', _onTouchStart);
+				_containerNode.removeEventListener('touchmove', _onTouchMove);
+				_containerNode.removeEventListener('touchend', _onTouchEnd);
+				_containerNode.removeEventListener('touchcancel', _onTouchEnd);
+				_containerNode.removeEventListener('mousedown', _onMouseDown);
+				_containerNode.removeEventListener('DOMMouseScroll', _onMouseScroll);
+				_containerNode.removeEventListener('mousewheel', _onMouseScroll);
 				_containerNode.removeEventListener('click', _onClick, true);
 			}
 
 			if (_contentParentNode) {
-				_contentParentNode.removeEventListener('focus', _childFocused, true);
-				_contentParentNode.removeEventListener('DOMSubtreeModified', _domChanged, true);
-				_contentParentNode.removeEventListener('load', _domChanged, true);
+				_contentParentNode.removeEventListener('focus', _childFocused);
+				_contentParentNode.removeEventListener('DOMSubtreeModified', _domChanged);
+				_contentParentNode.removeEventListener('load', _domChanged);
 			}
 
 			if (_mutationObserver) {
 				_mutationObserver.disconnect();
 			}
 
-			document.removeEventListener('mousemove', _onMouseMove, true);
-			document.removeEventListener('mouseup', _onMouseUp, true);
+			document.removeEventListener('mousemove', _onMouseMove);
+			document.removeEventListener('mouseup', _onMouseUp);
 			document.removeEventListener('click', _onClick, true);
-			window.removeEventListener('resize', _domChanged, true);
+			window.removeEventListener('resize', _domChanged);
 		};
 
 		/**


### PR DESCRIPTION
Recent changes in Windows event capture handling allow us to finally move to event bubbling instead of capturing, leading to nicer behaviour of nested scroller; this updates the approach in Issue #13 and Issue #71.
