### PR TITLE
Don't detect whether touch events are available assume they are so that touch emulation is supported

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -104,10 +104,7 @@ var FTScroller, CubicBezier;
 	var _ftscrollerMoving = false;
 
 	// Determine whether pointer events or touch events can be used
-	var _trackTouchEvents = false;
-	if ('propertyIsEnumerable' in window || 'hasOwnProperty' in window.document) {
-		_trackTouchEvents = !_trackPointerEvents && (window.propertyIsEnumerable('ontouchstart') || window.document.hasOwnProperty('ontouchstart'));
-	}
+	var _trackTouchEvents = !_trackPointerEvents;
 
 	// Determine whether to use modern hardware acceleration rules or dynamic/toggleable rules.
 	// Certain older browsers - particularly Android browsers - have problems with hardware


### PR DESCRIPTION
Don't look for the presence of ontouchstart because it is not present in chrome doing touch emulation when the detection is done. Nor does it get added once the touch emulation has started.