### PR TITLE
Add option to disable scroll wheel inversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Options must be specified at create-time by passing a JSON object as the second 
 * `flingBezier` The bezier curve to use for momentum-like flings. _(CubicBezier, default CubicBezier(0.103, 0.389, 0.307, 0.966))_
 * `bounceDecelerationBezier` The bezier curve to use for deceleration when a fling hits the bounds. _(CubicBezier, default CubicBezier(0, 0.5, 0.5, 1))_
 * `bounceBezier` The bezier curve to use for bouncebacks when the scroll exceeds the bounds. _(CubicBezier, default CubicBezier(0.7, 0, 0.9, 0.6))_
+* `invertScrollWheel` If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll wheels to scroll constrained content. _(boolean, default true)_
 
 ## Public interface
 

--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -303,7 +303,7 @@ var FTScroller, CubicBezier;
 
 			// If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll
 			// wheels to scroll constrained content.
-			inverseScrollWheel: true
+			invertScrollWheel: true
 		};
 
 
@@ -2385,7 +2385,7 @@ var FTScroller, CubicBezier;
 
 			// If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll
 			// wheels to scroll constrained content.
-			if (_instanceOptions.inverseScrollWheel && !_instanceOptions.scrollingY && !scrollDeltaX) {
+			if (_instanceOptions.invertScrollWheel && !_instanceOptions.scrollingY && !scrollDeltaX) {
 				scrollDeltaX = scrollDeltaY;
 				scrollDeltaY = 0;
 			}

--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -299,7 +299,11 @@ var FTScroller, CubicBezier;
 			// and the bounce bezier (used for bouncing back).
 			flingBezier: new CubicBezier(0.103, 0.389, 0.307, 0.966),
 			bounceDecelerationBezier: new CubicBezier(0, 0.5, 0.5, 1),
-			bounceBezier: new CubicBezier(0.7, 0, 0.9, 0.6)
+			bounceBezier: new CubicBezier(0.7, 0, 0.9, 0.6),
+
+			// If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll
+			// wheels to scroll constrained content.
+			inverseScrollWheel: true
 		};
 
 
@@ -2381,7 +2385,7 @@ var FTScroller, CubicBezier;
 
 			// If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll
 			// wheels to scroll constrained content.
-			if (!_instanceOptions.scrollingY && !scrollDeltaX) {
+			if (_instanceOptions.inverseScrollWheel && !_instanceOptions.scrollingY && !scrollDeltaX) {
 				scrollDeltaX = scrollDeltaY;
 				scrollDeltaY = 0;
 			}


### PR DESCRIPTION
On a project I am working on we were having some trouble with the code that converts Y scrolling to X scrolling on a horizontal scroller when using a mouse scroll wheel. The scrolling area in our project is quite large so the user could get stuck when trying to scroll up and down.

I've added an option to disable this feature. If you are ok with this extra feature being there it would be nice to get my fork into master. Also I wasn't too sure about the naming of the feature flag, so feedback on that is welcome.

Thanks.