### PR TITLE
Enable page scrolling when only one axis is used in the scroller

### DIFF
--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -733,6 +733,15 @@ var FTScroller, CubicBezier;
 				y: inputY - _gestureStart.y
 			};
 
+			// if only one axis scroll is used, bubble up the other scroll wheel event
+			// e.g. if only x axis scroll is used then scrolling y axis can bubble up to scroll the page
+			if(!_instanceOptions.invertScrollWheel && (
+					(_instanceOptions.scrollingX && !_instanceOptions.scrollingY && Math.abs(gesture.x) < Math.abs(gesture.y)) ||
+					(!_instanceOptions.scrollingX && _instanceOptions.scrollingY && Math.abs(gesture.x) > Math.abs(gesture.y))
+				)) {
+				return;
+			}
+
 			// Opera fix
 			if (inputTime <= 0) {
 				inputTime = Date.now();

--- a/lib/ftscroller.js
+++ b/lib/ftscroller.js
@@ -2383,6 +2383,15 @@ var FTScroller, CubicBezier;
 				}
 			}
 
+			// if only one axis scroll is used, bubble up the other scroll wheel event
+			// e.g. if only x axis scroll is used then scrolling y axis can bubble up to scroll the page
+			if(!_instanceOptions.invertScrollWheel && (
+					(_instanceOptions.scrollingX && !_instanceOptions.scrollingY && Math.abs(scrollDeltaX) < Math.abs(scrollDeltaY)) ||
+					(!_instanceOptions.scrollingX && _instanceOptions.scrollingY && Math.abs(scrollDeltaX) > Math.abs(scrollDeltaY))
+				)) {
+				return;
+			}
+
 			// If the scroller is constrained to an x axis, convert y scroll to allow single-axis scroll
 			// wheels to scroll constrained content.
 			if (_instanceOptions.invertScrollWheel && !_instanceOptions.scrollingY && !scrollDeltaX) {


### PR DESCRIPTION
When the cursor is within the scroller area, users cannot scroll the page using mouse wheel or trackpad.
To enable page scrolling, this guesses which axis the user wants to scroll and lets the event bubble up.
